### PR TITLE
JS2: remove a leading zero in a solution

### DIFF
--- a/js2/komponenty/cvlekce/hodiny.md
+++ b/js2/komponenty/cvlekce/hodiny.md
@@ -60,7 +60,7 @@ const times = [
   },
   {
     hours: 17,
-    minutes: 08,
+    minutes: 8,
   },
 ];
 


### PR DESCRIPTION
> Uncaught SyntaxError: Decimals with leading zeros are not allowed in strict mode.