### PR TITLE
feat(Příprava): upozornění na možné problémy s npx

### DIFF
--- a/priprava/instalace-nastroju/overeni.md
+++ b/priprava/instalace-nastroju/overeni.md
@@ -32,5 +32,4 @@ Postupujte dle následujicích kroků.
 
    ```
 
-   To je přesně ten případ, kdy se *něco pokazilo* a napište na Slack 😎
-
+   To je přesně ten případ, kdy se _něco pokazilo_ a napište na Slack 😎

--- a/priprava/instalace-nastroju/overeni.md
+++ b/priprava/instalace-nastroju/overeni.md
@@ -15,7 +15,7 @@ Postupujte dle následujicích kroků.
 
    ::fig[ukázka běhu ověření]{src=assets/overeni.gif}
 
-1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04-otazky`` na Slacku, lektoři a koučové s vámi problém vyřeší.
+1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04-otazky` na Slacku, lektoři a koučové s vámi problém vyřeší.
 
    Například se může stát, že se po spuštění výše uvedeného příkazu program nebude na nic ptát, vypíše následující chybu a ukončí se:
 

--- a/priprava/instalace-nastroju/overeni.md
+++ b/priprava/instalace-nastroju/overeni.md
@@ -15,7 +15,7 @@ Postupujte dle následujicích kroků.
 
    ::fig[ukázka běhu ověření]{src=assets/overeni.gif}
 
-1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04-otazky` na Slacku, lektoři a koučové s vámi problém vyřeší.
+1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04_otazky` na Slacku, lektoři a koučové s vámi problém vyřeší.
 
    Například se může stát, že se po spuštění výše uvedeného příkazu program nebude na nic ptát, vypíše následující chybu a ukončí se:
 

--- a/priprava/instalace-nastroju/overeni.md
+++ b/priprava/instalace-nastroju/overeni.md
@@ -13,6 +13,24 @@ Postupujte dle následujicích kroků.
 
    Tento příkaz spustí dotazník, který se vás zeptá na váš e-mail a jméno. E-mail zadejte ten, který jste použili při vytváření účtu na GitHubu.
 
-1. Pokud program záhlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, pomohou vám naši lektoři a kouči.
+   ::fig[ukázka běhu ověření]{src=assets/overeni.gif}
 
-::fig[ukázka běhu ověření]{src=assets/overeni.gif}
+1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04-otazky`` na Slacku, lektoři a koučové s vámi problém vyřeší.
+
+   Například se může stát, že se po spuštění výše uvedeného příkazu program nebude na nic ptát, vypíše následující chybu a ukončí se:
+
+   ```
+   npm ERR! code ENOENT
+   npm ERR! syscall lstat
+   npm ERR! path C:\Users\uzivatel\AAppData\Roaming\npm
+   npm ERR! errno -4058
+   npm ERR! enoent ENOENT: no such file or directory, lstat 'C:\Users\uzivatel\AppData\Roaming\npm'
+   npm ERR! enoent This is related to npm not being able to find a file.
+   npm ERR! enoent
+
+   npm ERR! A complete log of this run can be found in: C:\Users\uzivatel\AppData\Local\npm-cache\2023-…-debug-0.log
+
+   ```
+
+   To je přesně ten případ, kdy se *něco pokazilo* a napište na Slack 😎
+


### PR DESCRIPTION
V Node.js 18.17.0+ nainstalovaném na Windows 10/11 mimo doménu (pravděpodobně) je chyba, která brání spuštění `npx`.  Pokud jsou správné naše domněnky o tom, kdy k chybě dochází, setká se s tím většina účastnic při ověření instalace nástrojů. Je tedy vhodné je rovnou v textu lekce nasměrovat, že se mají zeptat na Slacku. Aspoň se naučí ptát :-) A my budeme mít přehled, jak častý je to problém.

Řešení je vytvořit příslušný adresář, stačí, když je prázdný:

```
mkdir %APPDATA%\npm
```

Viz související vlákno ve [Slacku](https://lecturersczechitas.slack.com/archives/C040LE8JZA4/p1691139770752039).