### PR TITLE
Přidání aktualizace `npm` do kapitolky o instalaci Node.js

### DIFF
--- a/priprava/instalace-nastroju/entry.yml
+++ b/priprava/instalace-nastroju/entry.yml
@@ -4,8 +4,8 @@ access: public
 sections:
   - prohlizec
   - vs-code
-  - node
   - git
+  - node
   - slozka
   - overeni
   - specialni-znaky

--- a/priprava/instalace-nastroju/node.md
+++ b/priprava/instalace-nastroju/node.md
@@ -12,12 +12,6 @@ Do terminálu napište následující příkaz:
 npm i -g npm
 ```
 
-Pozor na mezery, všechna písmena jsou malá, před `g` je jedna pomlčka. Vypíše se pár řádků o tom, z jaké verze na jakou verzi se `npm` aktualizuje (skončit byste měli na verzi 9.8.1 nebo novější) a po chvilce se objeví opět řádek s výzvou (končí zobáčkem `>` ve Windows nebo dolarem `$` na MacOS a Linuxu), za kterou můžete psát další příkaz. Můžete zkusit třeba příkaz:
-
-```shell
-npm -v
-```
-
-Ten vypíše aktuální verzi `npm` a hned skončí.
+Pozor na mezery, všechna písmena jsou malá, před `g` je jedna pomlčka. Vypíše se pár řádků o tom, z jaké verze na jakou verzi se `npm` aktualizuje (skončit byste měli na verzi 9.8.1 nebo novější) a po chvilce se objeví opět řádek s výzvou (končí zobáčkem `>` ve Windows nebo dolarem `$` na MacOS a Linuxu), za kterou můžete psát další příkaz.
 
 Okno terminálu se vám bude hodit ještě pro ověření celé instalace, takže ho ještě nezavírejte.

--- a/priprava/instalace-nastroju/node.md
+++ b/priprava/instalace-nastroju/node.md
@@ -2,6 +2,22 @@
 
 ::fig[logo Node.js]{src=assets/nodejs.svg size=10}
 
-Nyní je potřeba nainstalovat Node.js a balíčkovací systém NPM. Tyto programy slouží ke spouštění JavaScriptových programů a díky nim budeme moct vytvářet moderní webové stránky. Opět následujte instrukce na [oficiální stránce](https://nodejs.org). Stáhněte a nainstalujte verzi označenou jako LTS. V současné době je to verze `18.14.1 LTS`. Číslo verze může být i vyšší, pokud tento manuál čtete někdy v budoucnosti. Pokud už máte Node.js z dřívějška, stejně si nainstalujte nejnovější verzi.
+Nyní je potřeba nainstalovat Node.js a balíčkovací systém NPM. Tyto programy slouží ke spouštění JavaScriptových programů a díky nim budeme moct vytvářet moderní webové stránky. Opět následujte instrukce na [oficiální stránce](https://nodejs.org). Stáhněte a nainstalujte verzi označenou jako LTS. V současné době je to verze `18.17.1 LTS`. Číslo verze může být i vyšší, pokud tento manuál čtete někdy v budoucnosti. Pokud už máte Node.js z dřívějška, stejně si nainstalujte nejnovější verzi.
 
-NPM je součást instalace Node.js, takže se nainstaluje společně s ním. Není ho tedy potřeba řešit zvlášť.
+NPM je součást instalace Node.js, takže se nainstaluje společně s ním. Obvykle se tedy neřeší zvlášť, my ovšem **důrazně** doporučujeme i `npm` aktualizovat na nejnovější verzi, protože se tím odstraní i jedna nepěkná chyba v aktuální instalaci Node.js. K aktualizaci budete opět potřebovat terminál nebo-li příkazovou řádku. Pokud vám nezůstal otevřený z instalace gitu, znovu ho otevřete postupem popsaným v [czechitas-podklady.cz/git-instalace/](https://czechitas-podklady.cz/git-instalace/).
+
+Do terminálu napište následující příkaz:
+
+```shell
+npm i -g npm
+```
+
+Pozor na mezery, všechna písmena jsou malá, před `g` je jedna pomlčka. Vypíše se pár řádků o tom, z jaké verze na jakou verzi se `npm` aktualizuje (skončit byste měli na verzi 9.8.1 nebo novější) a po chvilce se objeví opět řádek s výzvou (končí zobáčkem `>` ve Windows nebo dolarem `$` na MacOS a Linuxu), za kterou můžete psát další příkaz. Můžete zkusit třeba příkaz:
+
+```shell
+npm -v
+```
+
+Ten vypíše aktuální verzi `npm` a hned skončí.
+
+Okno terminálu se vám bude hodit ještě pro ověření celé instalace, takže ho ještě nezavírejte.

--- a/priprava/instalace-nastroju/overeni.md
+++ b/priprava/instalace-nastroju/overeni.md
@@ -15,14 +15,14 @@ Postupujte dle následujicích kroků.
 
    ::fig[ukázka běhu ověření]{src=assets/overeni.gif}
 
-1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04_otazky` na Slacku, lektoři a koučové s vámi problém vyřeší.
+1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04_otazky-XXXX` na Slacku, lektoři a koučové s vámi problém vyřeší.
 
    Například se může stát, že se po spuštění výše uvedeného příkazu program nebude na nic ptát, vypíše následující chybu a ukončí se:
 
    ```
    npm ERR! code ENOENT
    npm ERR! syscall lstat
-   npm ERR! path C:\Users\uzivatel\AAppData\Roaming\npm
+   npm ERR! path C:\Users\uzivatel\AppData\Roaming\npm
    npm ERR! errno -4058
    npm ERR! enoent ENOENT: no such file or directory, lstat 'C:\Users\uzivatel\AppData\Roaming\npm'
    npm ERR! enoent This is related to npm not being able to find a file.
@@ -32,4 +32,4 @@ Postupujte dle následujicích kroků.
 
    ```
 
-   To je přesně ten případ, kdy se _něco pokazilo_ a napište na Slack 😎
+   To je přesně ten případ, kdy se _něco pokazilo_ a napište na Slack do `#04_otazky-XXXX` 😎

--- a/priprava/instalace-nastroju/overeni.md
+++ b/priprava/instalace-nastroju/overeni.md
@@ -15,7 +15,7 @@ Postupujte dle následujicích kroků.
 
    ::fig[ukázka běhu ověření]{src=assets/overeni.gif}
 
-1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04_otazky-XXXX` na Slacku, lektoři a koučové s vámi problém vyřeší.
+1. Pokud program zahlásí, že všechno proběhlo v pořádku, slavte úspěch. Pokud se cestou cokoliv pokazilo, napište do kanálu `#04_otazky-XXXX` na Slacku, lektoři a koučové s vámi problém vyřeší. Je dobré z terminálu do Slacku zkopírovat příkaz, který jste spustili, a celý jeho výstup. Můžete poslat i snímek obrazovky, ale kopie textu hezky zformátovaná jako kód je lepší (jak na to se dozvíte o dvě kapitolky dál v [Sdílení kódu v textových zprávách](kod-ve-zpravach)).
 
    Například se může stát, že se po spuštění výše uvedeného příkazu program nebude na nic ptát, vypíše následující chybu a ukončí se:
 
@@ -33,3 +33,8 @@ Postupujte dle následujicích kroků.
    ```
 
    To je přesně ten případ, kdy se _něco pokazilo_ a napište na Slack do `#04_otazky-XXXX` 😎
+
+1. Pokud oveření dopadlo dobře, můžete terminál zavřít zadáním příkazu
+   ```shell
+   exit
+   ```


### PR DESCRIPTION
Aktualizace `npm` by měla fungovat jako workaround pro chybu instalátoru Node.js 18.17.0+ ve Windows, který nevytváří adresář `%APPDATA%\npm`, ale zároveň nakonfiguruje `npm` tak, aby tento adresář používalo. Aktualizace `npm` tento adresář vytvoří.
Viz [vlákno na Slacku](https://lecturersczechitas.slack.com/archives/C040LE8JZA4/p1691139770752039).