### PR TITLE
fix(JS2.10): Komponenta `Drink` potřebuje prop `id`.

### DIFF
--- a/daweb/js2/cafe-lora-1/cvlekce/napoj.md
+++ b/daweb/js2/cafe-lora-1/cvlekce/napoj.md
@@ -13,6 +13,7 @@ Vytvoříme komponentu `Drink`, která zatím nebude mít funkční objednávac�
 
     ```jsx
     <Drink
+      id={0}
       name="Romano"
       ordered={false}
       image="https://localhost:4000/assets/cups/romano.png"


### PR DESCRIPTION
Komponenta `Drink` bude potřebovat `id` kvůli objednání.