### PR TITLE
Git 1: příkazy - restore místo reset

### DIFF
--- a/daweb/zaklady-gitu/uvod-do-gitu/dulezite-prikazy.md
+++ b/daweb/zaklady-gitu/uvod-do-gitu/dulezite-prikazy.md
@@ -4,13 +4,16 @@
 : Vytvoří lokální kopii vzdáleného repozitáře.
 
 **add**
-: Přidá změny do :term{cs="oblasti připravených změn" en="stage"}.
+: Přidá změny do :term{cs="oblasti připravených změn" en="stage, index"}.
 
 **status**
 : Zobrazí všechny rozpracované změny proti poslednímu commitu.
 
+**restore --staged**
+: Vyprázdní oblast připravených změn (experimentální!)
+
 **reset**
-: Vyprázdní oblast připravených změn.
+: Nebezpečnější alternativa příkazu `restore`.
 
 **commit**
 : Vytvoří novou revizi.


### PR DESCRIPTION
Popisek resetu je značně zavádějící, restore k tomu má trochu blíž a ideální řešení (pro akci "vyprázni stage") bohužel tak úplně neexistuje.

A stagi se v Gitu říká "Index".